### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,13 @@ Requirements
 
 * [x] [Create a free sipgate basic account](https://www.sipgate.de/basic)
 * [x] [Book the sipgate.io feature](https://www.sipgate.de/basic/feature-store/sipgate.io-s)
-* [x] [Enter an URL for incoming/outgoing calls in the dashboard](https://www.sipgate.de/basic/dashboard)
+* [x] [Enter an URL for incoming/outgoing calls in the dashboard](https://app.sipgate.com/w0/connections/phonelines/p0/dialog/sipgate-io-url/incoming)
 
 ### Usage with simquadrat
 
 * [x] [Order a simquadrat SIM](https://www.simquadrat.de)
 * [x] [Book the sipgate.io feature](https://www.simquadrat.de/feature-store/sipgate.io-s)
-* [x] [Enter an URL for incoming/outgoing calls in the dashboard](https://www.simquadrat.de/dashboard)
+* [x] [Enter an URL for incoming/outgoing calls in the dashboard](https://app.sipgate.com/w0/connections/phonelines/p0/dialog/sipgate-io-url/incoming)
 
 
 The POST request


### PR DESCRIPTION
https://sipgate.de/basic/dashboard und https://simquadrat.de/dashboard existieren nicht mehr. Stattdessen wird die Push-URL inzwischen auf https://app.sipgate.com/w0/connections/phonelines/p0/dialog/sipgate-io-url/incoming eingetragen.
Besser wäre es, wenn man hier https://app.sipgate.com/w0/connections/phonelines/p0/dialog/sipgate-io-url bzw. https://app.sipgate.com/w0/connections/phonelines/p0/dialog/#sipgate-io-url (als Anker, der runterscrollt zu sipgate.IO) verlinken könnte und das dann, sofern angemeldet, direkt das richtige Feld/Fenster zum Eintragen der URL öffnen würde.